### PR TITLE
Add a dummy DESTROY method

### DIFF
--- a/lib/Statistics/NiceR.pm
+++ b/lib/Statistics/NiceR.pm
@@ -81,6 +81,12 @@ sub AUTOLOAD {
 	return $perl_data;
 }
 
+sub DESTROY {
+	my $self = shift;
+	
+	return if ${^GLOBAL_PHASE} eq 'DESTRUCT';
+}
+
 1;
 
 =head1 SYNOPSIS


### PR DESCRIPTION
When installed on centos 7.3 with perl v5.16.3, Statistics::NiceR complains about a missing DESTROY method. This commit adds a dummy DESTROY method as per http://perldoc.perl.org/perlobj.html#Destructors