### PR TITLE
Fix compilation

### DIFF
--- a/lib/Statistics/NiceR/DataConvert/PDL.c.tmpl
+++ b/lib/Statistics/NiceR/DataConvert/PDL.c.tmpl
@@ -104,7 +104,7 @@ for my $type (qw(PDL_D PDL_L)) {
 	$OUT .= qq%
 	case $pdl_to_r->{$type}{sexptype}:
 	datad_$type = ($pdl_to_r->{$type}{ctype} *) p->data;
-	badv_$type = PDL->get_pdl_badvalue(p);
+	ANYVAL_TO_CTYPE(badv_$type, $pdl_to_r->{$type}{ctype}, PDL->get_pdl_badvalue(p));
 	memcpy( $pdl_to_r->{$type}{r_macro}(r_array), datad_$type, sizeof($pdl_to_r->{$type}{ctype}) * nelems );
 	if( p->state & PDL_BADVAL ) {
 		for( elem_i = 0; elem_i < nelems; elem_i++ ) {
@@ -165,7 +165,7 @@ for my $type (qw(PDL_D PDL_L)) {
 	$OUT .= qq%
 	case $type:
 	datad_$type = ($pdl_to_r->{$type}{ctype} *) p->data;
-	badv_$type = PDL->get_pdl_badvalue(p);
+	ANYVAL_TO_CTYPE(badv_$type, $pdl_to_r->{$type}{ctype}, PDL->get_pdl_badvalue(p));
 	memcpy( datad_$type, $pdl_to_r->{$type}{r_macro}(r_array), sizeof($pdl_to_r->{$type}{ctype}) * nelems );
 	for( elem_i = 0; elem_i < nelems; elem_i++ ) {
 		if( ISNA( $pdl_to_r->{$type}{r_macro}(r_array)[elem_i] ) ) {
@@ -226,7 +226,7 @@ for my $type (qw(PDL_D PDL_L)) {
 	$OUT .= qq%
 	case $type:
 	datad_$type = ($pdl_to_r->{$type}{ctype} *) p->data;
-	badv_$type = PDL->get_pdl_badvalue(p);
+	ANYVAL_TO_CTYPE(badv_$type, $pdl_to_r->{$type}{ctype}, PDL->get_pdl_badvalue(p));
 	memcpy( datad_$type, $pdl_to_r->{$type}{r_macro}(r_vector), sizeof($pdl_to_r->{$type}{ctype}) * nelems );
 	for( elem_i = 0; elem_i < nelems; elem_i++ ) {
 		if( ISNA( $pdl_to_r->{$type}{r_macro}(r_vector)[elem_i] ) ) {


### PR DESCRIPTION
* perl = `v5.26.0`
* pdl = `VERSION: PDL v2.018 (supports bad values)`
* gcc = `gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-16)`

When trying to compile on the above the following is seen.

```
Inline.xs:187:13: error: incompatible types when assigning to type 'PDL_Double' from type 'PDL_Anyval'
```

This PR makes use of the `ANYVAL_TO_CTYPE` macro to cast.